### PR TITLE
Auto gen otelcol

### DIFF
--- a/.github/workflows/on-pull_request.yaml
+++ b/.github/workflows/on-pull_request.yaml
@@ -72,22 +72,11 @@ jobs:
       # yamllint enable rule:line-length
       - name: Generate otelcol code
         run: ./ocb --config builder-config.yaml --skip-compilation
-      - name: Check for changes in otelcol directory
-        id: check_changes
-        run: |
-          if git status --porcelain otelcol/ | grep .; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Commit and push changes
-        if: steps.check_changes.outputs.changed == 'true'
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add otelcol/
-          git commit -m "Generate otelcol code"
-          git push
+      - name: Commit generated code
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403  # v5.2.0
+        with:
+          commit_message: Generate otelcol code
+          file_pattern: otelcol/*
 
   verify-otelcol-code:
     name: Check if the code of otelcol can be built

--- a/.github/workflows/on-pull_request.yaml
+++ b/.github/workflows/on-pull_request.yaml
@@ -12,8 +12,8 @@ jobs:
       pull-requests: write
     timeout-minutes: 5
     outputs:
-      otelcol_changed: ${{ steps.check_otelcol.outputs.any_changed }}
       builder_config_changed: ${{ steps.check_builder_config.outputs.any_changed }}
+      otelcol_changed: ${{ steps.check_otelcol.outputs.any_changed }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:

--- a/.github/workflows/on-pull_request.yaml
+++ b/.github/workflows/on-pull_request.yaml
@@ -13,10 +13,16 @@ jobs:
     timeout-minutes: 5
     outputs:
       otelcol_changed: ${{ steps.check_otelcol.outputs.any_changed }}
+      builder_config_changed: ${{ steps.check_builder_config.outputs.any_changed }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
+      - name: Check for changes in builder-config.yaml
+        id: check_builder_config
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # v46.0.5
+        with:
+          files: builder-config.yaml
       - name: Check for changes in otelcol directory
         id: check_otelcol
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # v46.0.5
@@ -43,6 +49,45 @@ jobs:
         with:
           fail_on_error: true
           reporter: github-pr-review
+
+  generate-otelcol:
+    name: Generate otelcol code
+    needs: judge-exec
+    if: needs.judge-exec.outputs.builder_config_changed == 'true'
+    permissions:
+      contents: write
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    env:
+      OCB_VERSION: 0.124.0
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
+      # yamllint disable rule:line-length
+      - name: Download ocb
+        run: |
+          wget "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv${OCB_VERSION}/ocb_${OCB_VERSION}_linux_amd64" -O ocb
+          chmod +x ocb
+      # yamllint enable rule:line-length
+      - name: Generate otelcol code
+        run: ./ocb --config builder-config.yaml --skip-compilation
+      - name: Check for changes in otelcol directory
+        id: check_changes
+        run: |
+          if git status --porcelain otelcol/ | grep .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Commit and push changes
+        if: steps.check_changes.outputs.changed == 'true'
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add otelcol/
+          git commit -m "Generate otelcol code"
+          git push
 
   verify-otelcol-code:
     name: Check if the code of otelcol can be built


### PR DESCRIPTION
```
pull requestでbuilder-config.yamlファイルが更新された際に、ocbでコードを生成してcommitを追加するステップを追加してください。具体的な変更を示します。
まづjudge-execジョブでbuild-config.yamlが変更されたか否かを確認します。
新しいgenerate-otelcolジョブを追加します。build-config.yamlファイルがpull requestで変更されていればこのジョブを実行し、変更されていなければ何もしません。
generate-otelcolジョブは以下のステップを実行します。
まづバージョンを指定してocbをダウンロードします。現在のバージョンは0.124.0で、ダウンロードURLは https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv0.124.0/ocb_0.124.0_linux_amd64 です。バージョンはパラメーターとして指定できるようにしてください。
次にotelcolのコードを生成します。コマンドはocb --config builder-config.yaml --skip-compilationを実行してください。
次にotelcol/ディレクトリに差分があるか否かを確認し、もし差分があればpull requestにcommitを追加してください。差分が無ければ何もしないでください。
以上です。
```

```
Commit and push changesステップを、stefanzweifel/git-auto-commit-action@v5アクションを使うよう書き直してください。
```