### PR TITLE
ignore[dangerous-triggers]

### DIFF
--- a/.github/workflows/on-pull_request-workflow_run-completed.yaml
+++ b/.github/workflows/on-pull_request-workflow_run-completed.yaml
@@ -2,7 +2,7 @@
 name: on pull_request workflow_run completed
 
 "on":
-  workflow_run:
+  workflow_run:  # zizmor: ignore[dangerous-triggers]
     workflows:
       - on pull_request
     types:

--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,7 @@ lint: lint-gha ## Lint the code
 	plutil -lint com.github.open-telemetry.opentelemetry-collector.plist
 
 lint-gha:
-	yamllint .github/workflows/*.yaml
+	yamllint .github/workflows/
 	actionlint
+	ghalint run
+	zizmor .


### PR DESCRIPTION
```
error[dangerous-triggers]: use of fundamentally insecure workflow trigger
 --> ./.github/workflows/on-pull_request-workflow_run-completed.yaml:4:1
  |
4 | / "on":
5 | |   workflow_run:
... |
8 | |     types:
9 | |       - completed
  | |_________________^ workflow_run is almost always used insecurely
  |
  = note: audit confidence → Medium
```