### PR TITLE
Dependabotのsecurity updateにotelcol/ directory以下を無視させる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+        directories:
+          - "otelcol/"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 0

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,4 @@ lint-otelcol:
 
 lint-renovate:
 	npx --package renovate -- renovate-config-validator
+	yamllint .github/dependabot.yml


### PR DESCRIPTION
https://github.com/ne-sachirou/otelcol-config/pull/71 はpull requestを作ってくれていいけど https://github.com/ne-sachirou/otelcol-config/pull/72 は作ってほしくない。